### PR TITLE
feat: add support for L1Loss and NLLLoss

### DIFF
--- a/slowtorch/nn/functional.py
+++ b/slowtorch/nn/functional.py
@@ -1697,3 +1697,107 @@ def mse_loss(input: Tensor, target: Tensor, reduction: str = "mean") -> Tensor:
     new_tensor.grad_fn = Node(MseLossBackward0)
     new_tensor.grad_fn.inputs = (input, target)
     return new_tensor
+
+
+@function_dispatch
+def l1_loss(input: Tensor, target: Tensor, reduction: str = "mean") -> Tensor:
+    """Compute the Mean Absolute Error (MAE) loss between two tensors.
+
+    This function calculates the average of the absolute differences
+    between `input` and `target` tensors. It supports autograd for
+    backpropagation.
+
+    :param input: The input tensor representing predictions.
+    :param target: The target tensor representing true values.
+    :param reduction: The reduction function to apply to the computed
+        loss. Options are::
+            - `mean`: Return the average of the absolute differences.
+            - `sum`: Return the sum of the absolute differences.
+            - `none`: Return the absolute differences without reduction.
+        Defaults to `mean`.
+    :return: A scalar tensor representing the MAE loss.
+    """
+    loss = abs(input - target)
+    if reduction == "mean":
+        new_tensor = loss.sum() / loss.nelement()
+        grad_fn = "MeanBackward0"
+    elif reduction == "sum":
+        new_tensor = loss.sum()
+        grad_fn = "SumBackward0"
+    elif reduction == "none":
+        new_tensor = loss
+        grad_fn = "AbsBackward0"
+
+    def L1LossBackward0() -> None:
+        """Backpropagation implementation for MAE loss.
+
+        Computes gradients for the `input` and `target` tensors and
+        propagates them backward through the computational graph.
+        """
+        if None in (input.grad, target.grad):
+            input.grad = target.grad = Tensor(input.shape, input.dtype)
+        grad = 2.0 / loss.nelement() if reduction == "mean" else 2.0
+        input.grad += grad * loss
+        target.grad -= grad * loss
+
+    L1LossBackward0.__name__ = grad_fn
+    new_tensor.grad_fn = Node(L1LossBackward0)
+    new_tensor.grad_fn.inputs = (input, target)
+    return new_tensor
+
+
+@function_dispatch
+def nll_loss(input: Tensor, target: Tensor, reduction: str = "mean") -> Tensor:
+    """Compute the Negative Log Likelihood (NLL) loss.
+
+    This loss is useful to train a classification problem with `C`
+    classes. The input is expected to contain log-probabilities
+    (typically output of `log_softmax`), and the target contains the
+    class indices. It supports autograd for backpropagation.
+
+    :param input: The input tensor of shape (N, C) where C = number of
+        classes.
+    :param target: The target of shape (N,) with class indices in
+        [0, C-1].
+    :param reduction: The reduction function to apply to the computed
+        loss. Options are::
+            - `mean`: Return the average of the absolute differences.
+            - `sum`: Return the sum of the absolute differences.
+            - `none`: Return the absolute differences without reduction.
+        Defaults to `mean`.
+    :return: A scalar tensor representing the NLL loss.
+    """
+    loss = Tensor(
+        shape=input.shape[0],
+        dtype=input.dtype,
+        device=input.device,
+        requires_grad=input.requires_grad,
+    )
+    loss[:] = (-input[dim, target[dim]] for dim in range(input.shape[0]))
+    if reduction == "mean":
+        new_tensor = loss.sum() / loss.nelement()
+    elif reduction == "sum":
+        new_tensor = loss.sum()
+    elif reduction == "none":
+        new_tensor = loss
+
+    def NllLossBackward0() -> None:
+        """Backpropagation implementation for NLL loss.
+
+        Computes gradients for the `input` and `target` tensors and
+        propagates them backward through the computational graph.
+        """
+        grad = Tensor(input.shape, input.dtype)
+        for dim in range(input.shape[0]):
+            grad[dim, target[dim]] = -1.0
+        if reduction == "mean":
+            for dim in range(input.shape[0]):
+                grad[dim, target[dim]] /= input.shape[0]
+        if input.grad is None:
+            input.grad = grad
+        else:
+            input.grad += grad
+
+    new_tensor.grad_fn = Node(NllLossBackward0)
+    new_tensor.grad_fn.inputs = (input, target)
+    return new_tensor


### PR DESCRIPTION
- this pr adds support for calculating `l1_loss` (mean absolute error) and `nll_loss` (negative log likelihood) loss functions along with class forms.
- this also adds support for respective backward pass methods to go along them. 