### PR TITLE
refactor: add tensor to VF and fix docs

### DIFF
--- a/slowtorch/_random.py
+++ b/slowtorch/_random.py
@@ -18,7 +18,6 @@ import random
 from slowtorch import function_dispatch
 from slowtorch._tensor import DeviceType
 from slowtorch._tensor import Tensor
-from slowtorch._tensor import tensor
 
 
 @function_dispatch
@@ -44,6 +43,8 @@ class Generator:
 
         :return: State of RNG as a `slowtorch.Tensor`.
         """
+        from slowtorch._variable_functions import tensor
+
         return tensor(self.internal.getstate())
 
     def set_state(self, state: tuple[int, ...]) -> None:


### PR DESCRIPTION
- this pr refactors and fixes the inconsistencies within the docstrings.
- `Tensor.__getitem__` now supports indexing via a `tensor` object.
- `tensor` is now (again) a functional implementation rather than a class based implementation. `tensor` is also now in the `_VF` (_variable_function) module instead of `_tensor`. 