### PR TITLE
fix: correct type hints in tensor module

### DIFF
--- a/slowtorch/internal/tensor.py
+++ b/slowtorch/internal/tensor.py
@@ -83,6 +83,7 @@ if t.TYPE_CHECKING:
     from slowtorch.types import Dim
     from slowtorch.types import Dtype
     from slowtorch.types import FloatLikeType
+    from slowtorch.types import Id
     from slowtorch.types import IndexLike
     from slowtorch.types import Input
     from slowtorch.types import IntLikeType
@@ -1066,7 +1067,6 @@ class Tensor:
         seen: set[IntLikeType] = set()
         shown: set[IntLikeType] = set()
         counter: list[IntLikeType] = [1]
-        Id: t.TypeAlias = list[IntLikeType] | IntLikeType
         tensors: OrderedDict[IntLikeType, Id] = OrderedDict()
 
         def set_id(input: Tensor) -> None:

--- a/slowtorch/types.py
+++ b/slowtorch/types.py
@@ -44,6 +44,7 @@ __all__: list[str] = [
     "FileLike",
     "FloatLikeType",
     "IndexLike",
+    "Id",
     "Input",
     "IntLikeType",
     "ParamGroup",
@@ -73,6 +74,7 @@ StrideType: t.TypeAlias = list[IntLikeType] | tuple[IntLikeType, ...]
 TensorOrTensors: t.TypeAlias = tuple[Tensor, ...] | Tensor
 ParamGroup: t.TypeAlias = dict[str, t.Any]
 ModuleType: t.TypeAlias = t.Iterator[None | Module]
+Id: t.TypeAlias = list[IntLikeType] | IntLikeType
 FileLike: t.TypeAlias = (
     IntLikeType | str | bytes | os.PathLike[str] | os.PathLike[bytes]
 )


### PR DESCRIPTION
- this commit fixes the typing alias' issue which breaks the rendering of the nodes